### PR TITLE
Corrige erro de update de horários de um dia  desa

### DIFF
--- a/app/Controllers/Http/DisableDayController.js
+++ b/app/Controllers/Http/DisableDayController.js
@@ -93,6 +93,8 @@ class DisableDayController {
           betweenSchedules.push(i)
         }
 
+        await disableDays.schedules().detach()
+
         betweenSchedules.forEach(async (selected) => {
           const schedule = await Schedule.findBy('hour', selected)
           await disableDays.schedules().attach([schedule.id])


### PR DESCRIPTION
Quando tentamos atualizar o horário de um dia desativado, ocorria um erro pois o vetor de horário anterios não era apagado da tabela do banco de dados.
Este pull request resolve isso.